### PR TITLE
Fix MQTT subscriptions and logging

### DIFF
--- a/inc/cdb_mqtt_handler.h
+++ b/inc/cdb_mqtt_handler.h
@@ -25,6 +25,7 @@ namespace cdb {
             static cdb::Logger * logger;
             mosquitto * mosq;
             cdb::CallbackClass * bot;
+            cdb::Configurator * conf;
 
             void (cdb::MqttHandler::*loggerptr)(mosquitto *, void *, int, const char *);
 
@@ -93,6 +94,23 @@ namespace cdb {
              * @param msg The message information
              */
             void message_cb(cdb::callback_msg * msg);
+
+            /**
+             * @brief To be called by the mosquitto callback
+             */
+            void on_connect_cb(void);
+
+            /**
+             * @brief To be called by the mosquitto callback
+             */
+            void on_disconnect_cb(void);
+
+            /**
+             * @brief To be called by the mosquitto callback
+             *
+             * @param message The message received
+             */
+            void on_message_cb(const mosquitto_message *message);
     };
 }
 

--- a/src/cdb_mqtt_handler.cpp
+++ b/src/cdb_mqtt_handler.cpp
@@ -13,33 +13,68 @@ static std::map<std::string, std::string> cmnd_topic_map;
 
 static void on_connect(mosquitto * m, void *obj, int res)
 {
-    //printf("mqtt on connect res %d\n", res);
+    cdb::MqttHandler * handler = (cdb::MqttHandler *) obj;
+    handler->on_connect_cb();
 }
 
 static void on_disconnect(mosquitto * m, void *obj, int res)
 {
-    //printf("mqtt on disconnect res %d\n", res);
+    cdb::MqttHandler * handler = (cdb::MqttHandler *) obj;
+    handler->on_disconnect_cb();
 }
 
 static void on_message(mosquitto * m, void *obj, const mosquitto_message *message)
 {
+    cdb::MqttHandler * handler = (cdb::MqttHandler *) obj;
+    handler->on_message_cb(message);
+}
+
+cdb::MqttHandler::MqttHandler(void)
+{
+}
+
+void cdb::MqttHandler::on_connect_cb(void)
+{
+    cdb::Configurator *conf = this->conf;
+    std::list<cdb::MqttDevice *> * l = conf->inventory.mqtt_dev_list();
+    logger->info("MQTT Handler: On Connect");
+
+    std::list<cdb::MqttDevice *>::iterator it;
+    for (it = l->begin(); it != l->end(); ++it){
+        logger->info("MQTT Handler: Adding device " + (*it)->name());
+        this->add_device(*it);
+        cdb::callback_msg msg = { CDB_MSG_DISC_MQTT_DEV_ADD,
+                                 (*it)->name()};
+        stat_topic_map[(*it)->stat()] = (*it)->name();
+        cmnd_topic_map[(*it)->name()] = (*it)->cmnd();
+        this->bot->message_cb(&msg);
+    }
+}
+
+void cdb::MqttHandler::on_disconnect_cb(void)
+{
+    logger->warn("MQTT Handler: On Disconnect");
+}
+
+void cdb::MqttHandler::on_message_cb(const mosquitto_message *message)
+{
     cdb::msg_t type = cdb::CDB_MSG_MAX;
-    printf("mqtt message %s\n", (char*) message->payload);
+    std::string msg = (char*) message->payload;
+    logger->info("MQTT Handler: Received message " + msg + " for device " + stat_topic_map[message->topic]);
+
     if (stat_topic_map.find(message->topic) != stat_topic_map.end()){
         if (strcmp((char*) message->payload, "ON") == 0){
             type = cdb::CDB_MSG_DISC_MQTT_DEV_STATUS_ON;
         } else if (strcmp((char*) message->payload, "OFF") == 0){
             type = cdb::CDB_MSG_DISC_MQTT_DEV_STATUS_OFF;
+        } else {
+            logger->warn("MQTT Handler: Could not determine message type");
+            return;
         }
 
-        std::cout << "device " + stat_topic_map[message->topic] + "\n";
         cdb::callback_msg  msg = {type, stat_topic_map[message->topic]};
         my_bot->message_cb(&msg);
     }
-}
-
-cdb::MqttHandler::MqttHandler(void)
-{
 }
 
 void cdb::MqttHandler::set_logger(cdb::Logger * l)
@@ -51,7 +86,6 @@ void cdb::MqttHandler::set_discord_bot(cdb::CallbackClass * disc_bot)
 {
     this->bot = disc_bot;
     my_bot = disc_bot;
-    std::cout << "bot is now " << my_bot << "\n";
 }
 
 void cdb::MqttHandler::message_cb(cdb::callback_msg * msg)
@@ -59,6 +93,8 @@ void cdb::MqttHandler::message_cb(cdb::callback_msg * msg)
     const char * cmd_on   = "1";
     const char * cmd_off  = "0";
     const char * cmd_poll = "";
+
+    this->logger->info("MQTT Handler: Received bot msg: " + msg->content);
 
     switch(msg->type){
         case CDB_MSG_MQTT_HANDLER_TURN_DEVICE_ON:
@@ -71,40 +107,52 @@ void cdb::MqttHandler::message_cb(cdb::callback_msg * msg)
             this->publish(cmnd_topic_map[msg->content].c_str(), sizeof(cmd_poll), cmd_poll);
             break;
         default:
-            this->logger->warn("Unexpected message type: " + std::to_string(msg->type));
+            this->logger->warn("MQTT Handler: Unexpected message type: " + std::to_string(msg->type));
     }
 }
 
 void cdb::MqttHandler::mosq_logger(mosquitto *mosq, void *obj, int level, const char *str)
 {
-    std::string msg = str;
-    logger->debug("MQTT Handler: " + msg);
+    std::string msg = "MQTT Handler: ";
+    msg += str;
+
+    switch(level){
+        case MOSQ_LOG_DEBUG:
+            logger->debug(msg);
+            break;
+        case MOSQ_LOG_INFO:
+        case MOSQ_LOG_NOTICE:
+            logger->info(msg);
+            break;
+        case MOSQ_LOG_WARNING:
+            logger->warn(msg);
+            break;
+        case MOSQ_LOG_ERR:
+        default:
+            logger->error(msg);
+            break;
+    }
 }
 
 void cdb::MqttHandler::init(cdb::Configurator * conf)
 {
+    this->conf = conf;
     cdb::MqttServer * broker = conf->inventory.mqtt_server();
+    std::list<cdb::MqttDevice *> * l = conf->inventory.mqtt_dev_list();
 
     if (broker == NULL) {
-        logger->info("No MQTT broker configured, skipping MQTT setup");
+        logger->info("MQTT Handler: No MQTT broker configured, skipping MQTT setup");
         return;
     }
 
-    std::list<cdb::MqttDevice *> * l = conf->inventory.mqtt_dev_list();
-
     if (l == NULL) {
-        logger->info("No MQTT devices configured, skipping MQTT setup");
+        logger->info("MQTT Handler: No MQTT devices configured, skipping MQTT setup");
+        return;
     }
-
-//    if (CDB_MQTT_OK != res){
-//        logger.error("Connection to broker failed, error " + std::to_string(res));
-//    } else {
-//        logger.info("Connected to broker.");
-//    }
 
     mosquitto_lib_init();
 
-    this->mosq = mosquitto_new(broker->client_id().c_str(), true, NULL);
+    this->mosq = mosquitto_new(broker->client_id().c_str(), true, this);
     mosquitto_username_pw_set(this->mosq, broker->username().c_str(),
                                           broker->password().c_str());
 
@@ -117,37 +165,28 @@ void cdb::MqttHandler::init(cdb::Configurator * conf)
     this->connect(broker);
 
     mosquitto_loop_start(this->mosq);
-
-    std::list<cdb::MqttDevice *>::iterator it;
-    for (it = l->begin(); it != l->end(); ++it){
-        logger->info("Adding device " + (*it)->name());
-        this->add_device(*it);
-        cdb::callback_msg msg = { CDB_MSG_DISC_MQTT_DEV_ADD,
-                                 (*it)->name()};
-        stat_topic_map[(*it)->stat()] = (*it)->name();
-        cmnd_topic_map[(*it)->name()] = (*it)->cmnd();
-        this->bot->message_cb(&msg);
-    }
 }
 
 int cdb::MqttHandler::connect(cdb::MqttServer * conf)
 {
     int res = mosquitto_connect(this->mosq, conf->addr().c_str(), conf->port(), 30);
     if (MOSQ_ERR_SUCCESS != res){
-        logger->error("Connection to MQTT broker failed, error " + std::to_string(res));
+        logger->error("MQTT Handler: Connection to MQTT broker failed, error " + std::to_string(res));
         return CDB_NOK;
     }
 
-    logger->info("Connected to MQTT broker.");
+    logger->info("MQTT Handler: Connected to MQTT broker.");
     return CDB_OK;
 }
 
 void cdb::MqttHandler::add_device(cdb::MqttDevice * device)
 {
-    mosquitto_subscribe(this->mosq, NULL, device->stat().c_str(), 1);
+    mosquitto_subscribe(this->mosq, NULL, device->stat().c_str(), 2);
 }
 
 void cdb::MqttHandler::publish(const char * topic, int payload_len, const void * payload)
 {
-    mosquitto_publish(this->mosq, NULL, topic, payload_len, payload, 1, false);
+    std::string msg = (char*) payload;
+    logger->info("MQTT Handler: Publish message " + msg);
+    mosquitto_publish(this->mosq, NULL, topic, payload_len, payload, 2, false);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ int main(int argc, char** argv)
 
     std::string config_file = argv[1];
 
-    cdb::Logger logger = cdb::Logger(cdb::CDB_LOG_DEBUG);
+    cdb::Logger logger = cdb::Logger(cdb::CDB_LOG_INFO);
 
     cdb::IO io;
     cdb::Configurator conf;


### PR DESCRIPTION
 * Now passing to the mosquitto cbs a pointer to the MQTT handler object and using that to call logger and cbs in the object itself
 * Now using the logger exclusively for output in the MQTT handler
 * Mapped mosquitto log severities to cdb severities
 * Changed mqtt QoS 2 (No obvious effect)
 * MQTT device subscription occurs in the on_connect callback
 * Test that connect/reconnect works as expected